### PR TITLE
Gebeurtenissen bevragen abonnee

### DIFF
--- a/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
+++ b/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
@@ -35,17 +35,6 @@ Functionaliteit: Gebeurtenissen bevragen
       Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'szw'
       Dan wordt de 'verhuisd.intergemeentelijk' gebeurtenis van 'Piet' geleverd
 
-  Regel: Een gebeurtenis 'verhuisd.intergemeentelijk' wordt geleverd met het burgerservicenummer van de betreffende persoon en de datum vanaf wanneer deze hier verblijft
-
-    Scenario: De gebeurtenis wordt geleverd met burgerservicenummer en datum vanaf
-      Gegeven abonnee 'szw' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
-      En de aangifte van adreswijziging van 'Jan' is verwerkt
-      * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
-      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'szw'
-      Dan wordt een 'verhuisd.intergemeentelijk' gebeurtenis geleverd met de volgende data
-      * het burgerservicenummer van 'Jan'
-      * de vanaf datum van de opgave van verhuizing van 'Jan'
-
   Regel: Een abonnee ontvangt steeds de oudste ongelezen gebeurtenissen met een maximum van 10
 
     Scenario: Er zijn meer dan 10 gebeurtenissen en de abonnee ontvangt de oudste 10 gebeurtenissen

--- a/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
+++ b/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
@@ -9,60 +9,64 @@ Functionaliteit: Gebeurtenissen bevragen
   zodat ik niet zelf een distributiesysteem hoef te ontwikkelen/inkopen dat binnenkomende gebeurtenissen verdeelt onder mijn interne afnemers
 
   Achtergrond:
-    Gegeven de afnemer 'Hengelo' heeft abonnees 'SZW en JZ' geregistreerd
+    Gegeven de afnemer 'Hengelo' heeft abonnees 'szw en jz' geregistreerd
     En het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
     * in gemeente 'Hengelo'
     En het adres 'Stadserf_1_Roosendaal'
     * in gemeente 'Roosendaal'
-    Gegeven 'Jan en Piet' verblijven vanaf '14-4-2020' op het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
+    Gegeven 'Jan en Piet' verblijven vanaf 2 jaar geleden op het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
 
-  Regel: Een abonnee ontvangt steeds de oudste ongelezen gebeurtenis
+  Regel: Een abonnee ontvangt ongelezen gebeurtenissen
 
     Scenario: De abonnee heeft nog geen gebeurtenissen gevraagd
-      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      Gegeven abonnee 'szw' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
       En de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
-      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'szw'
       Dan wordt de 'verhuisd.intergemeentelijk' gebeurtenis van 'Jan' geleverd
 
-    Scenario: Er zijn meerdere gebeurtenissen dus de abonnee ontvangt de oudste gebeurtenis
-      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan en Piet'
+    Scenario: De eerste gebeurtenis is al gelezen dus de abonnee ontvangt alleen de ongelezen gebeurtenis
+      Gegeven abonnee 'szw' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan en Piet'
       En de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf 3 dagen geleden op het adres 'Stadserf_1_Roosendaal'
+      En een ongelezen gebeurtenis is gevraagd door abonnee 'szw'
       En de aangifte van adreswijziging van 'Piet' is verwerkt
       * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
-      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
-      Dan wordt de 'verhuisd.intergemeentelijk' gebeurtenis van 'Jan' geleverd
-
-    Scenario: De eerste van meerdere gebeurtenissen is al gelezen dus de abonnee ontvangt de tweede gebeurtenis
-      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan en Piet'
-      En de aangifte van adreswijziging van 'Jan' is verwerkt
-      * verblijft vanaf 3 dagen geleden op het adres 'Stadserf_1_Roosendaal'
-      En de aangifte van adreswijziging van 'Piet' is verwerkt
-      * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
-      En een ongelezen gebeurtenis is gevraagd door abonnee 'SZW'
-      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'szw'
       Dan wordt de 'verhuisd.intergemeentelijk' gebeurtenis van 'Piet' geleverd
 
   Regel: Een gebeurtenis 'verhuisd.intergemeentelijk' wordt geleverd met het burgerservicenummer van de betreffende persoon en de datum vanaf wanneer deze hier verblijft
 
     Scenario: De gebeurtenis wordt geleverd met burgerservicenummer en datum vanaf
-      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      Gegeven abonnee 'szw' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
       En de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
-      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'szw'
       Dan wordt een 'verhuisd.intergemeentelijk' gebeurtenis geleverd met de volgende data
       * het burgerservicenummer van 'Jan'
       * de vanaf datum van de opgave van verhuizing van 'Jan'
 
+  Regel: Een abonnee ontvangt steeds de oudste ongelezen gebeurtenissen met een maximum van 10
+
+    Scenario: Er zijn meer dan 10 gebeurtenissen en de abonnee ontvangt de oudste 10 gebeurtenissen
+      Gegeven 'Willem, Annet, Gijs, Belle, Sterre en Noa' verblijven vanaf 2 jaar geleden op het adres 'Stadserf_1_Roosendaal'
+      En 'Elsa, Luca en Sam' verblijven vanaf 2 jaar geleden op het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
+      Gegeven abonnee 'szw' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan, Piet, Willem, Annet, Gijs, Belle, Noa, Elsa, Luca en Sam'
+      En de aangiftes van adreswijziging van 'Jan, Piet, Elsa, Luca en Sam' zijn verwerkt
+      * verblijven vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
+      En de aangiftes van adreswijziging van 'Willem, Annet, Gijs, Belle, Sterre en Noa' zijn verwerkt
+      * verblijven vanaf gisteren op het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'szw'
+      Dan worden de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan, Piet, Elsa, Luca, Sam, Willem, Annet, Gijs, Belle en Sterre' geleverd
+
   Regel: Als er voor de abonnee geen ongelezen gebeurtenissen zijn, krijgt hij een leeg antwoord
 
     Scenario: De abonnee heeft alle ongelezen gebeurtenissen al gevraagd
-      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      Gegeven abonnee 'szw' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
       En de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
-      En alle ongelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
-      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      En alle ongelezen gebeurtenissen zijn gevraagd door abonnee 'szw'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'szw'
       Dan wordt er geen gebeurtenis geleverd
 
   Regel: Een abonnee krijgt alleen een gebeurtenis wanneer hij een abonnement heeft op het type gebeurtenis voor de persoon waarop de gebeurtenis heeft plaatsgevonden
@@ -70,32 +74,32 @@ Functionaliteit: Gebeurtenissen bevragen
     Scenario: De abonnee vraagt ongelezen gebeurtenissen en is niet geabonneerd op de gebeurtenis
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
-      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'szw'
       Dan wordt er geen gebeurtenis geleverd
 
     Scenario: De abonnee vraagt ongelezen gebeurtenissen en een is geabonneerd op het gebeurtenistype voor een andere persoon
-      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
+      Gegeven abonnee 'szw' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
       En de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
-      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'szw'
       Dan wordt er geen gebeurtenis geleverd
 
     Scenario: De abonnee vraagt ongelezen gebeurtenissen en een is geabonneerd op een ander gebeurtenistype voor de persoon
-      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.naar-buitenland' gebeurtenissen van 'Jan'
+      Gegeven abonnee 'szw' is geabonneerd op de 'verhuisd.naar-buitenland' gebeurtenissen van 'Jan'
       En de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
-      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'szw'
       Dan wordt er geen gebeurtenis geleverd
 
   Regel: Meerdere abonnees kunnen dezelfde gebeurtenis ontvangen
 
     Scenario: De abonnee vraagt ongelezen gebeurtenissen en een andere abonnee heeft de gebeurtenis al gevraagd
-      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
-      En abonnee 'JZ' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      Gegeven abonnee 'szw' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En abonnee 'jz' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
       En de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
-      En alle ongelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
-      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'JZ'
+      En alle ongelezen gebeurtenissen zijn gevraagd door abonnee 'szw'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'jz'
       Dan wordt de 'verhuisd.intergemeentelijk' gebeurtenis van 'Jan' geleverd
 
   Regel: Een abonnee ontvangt alleen gebeurtenissen die hebben plaatsgevonden na het plaatsen van het abonnement daarop
@@ -105,27 +109,21 @@ Functionaliteit: Gebeurtenissen bevragen
     Scenario: De gebeurtenis heeft plaatsgevonden vóór het abonement is gezet
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
-      En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
-      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      En abonnee 'szw' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'szw'
       Dan wordt er geen gebeurtenis geleverd
-
-  Regel: Bij het vragen van ongelezen gebeurtenissen is het opgeven van de abonnee verplicht
-
-    Scenario: Afnemer vraagt ongelezen gebeurtenissen zonder de abonnee op te geven
-      Als een ongelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo'
-      Dan is de response '400 Bad Request'
 
   Regel: Alleen een abonnee mag gebeurtenissen bevragen
 
     Scenario: Afnemer vraagt ongelezen gebeurtenissen en vult bij abonnee iets anders in dan een abonnee
-      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'WMO'
-      Dan is de response '403 Forbidden'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'wmo'
+      Dan is de response '404 Not found
 
   Regel: Gebeurtenissen ouder dan 2 maanden zijn ze niet meer op te vragen
 
     Scenario: De gebeurtenis heeft meer dan 2 maanden geleden plaatsgevonden en de abonnee wil deze nu nog lezen
-      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
-      En 3 maanden geleden om 9:32 uur is de aangifte van adreswijziging van 'Jan' verwerkt
+      Gegeven abonnee 'szw' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En 3 maanden geleden is de aangifte van adreswijziging van 'Jan' verwerkt
       * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
-      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'szw'
       Dan wordt er geen gebeurtenis geleverd

--- a/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
+++ b/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
@@ -4,20 +4,14 @@ Functionaliteit: Gebeurtenissen bevragen
   wil ik niet-gelezen gebeurtenissen chronologisch kunnen bevragen
   zodat ik asynchroon de gebeurtenissen waarop ik ben geabonneerd kan verwerken
 
-  Als consumer van BRP Gebeurtenissen
-  wil ik gebeurtenissen als niet-gelezen kunnen markeren
-  zodat ik de gebeurtenissen opnieuw kan verwerken
-
   Als gemeente 
   wil ik dat mijn interne afnemers zelf eigen abonnementen kunnen hebben en niet-gelezen eigen gebeurtenissen kunnen opvragen
   zodat ik niet zelf een distributiesysteem hoef te ontwikkelen/inkopen dat binnenkomende gebeurtenissen verdeelt onder mijn interne afnemers
 
   Achtergrond:
-    Gegeven de afnemer 'Hengelo'
-    * is geregistreerd als abonnee 'SZW' van BRP API Gebeurtenissen
-    * is geregistreerd als abonnee 'JZ' van BRP API Gebeurtenissen
-    * is geregistreerd als abonnee 'Belastingen' van BRP API Gebeurtenissen
-    Gegeven het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
+    Gegeven de afnemer 'Hengelo' heeft abonnee 'SZW' geregistreerd
+    En de afnemer 'Hengelo' heeft abonnee 'JZ' geregistreerd
+    En het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
     * in gemeente 'Hengelo'
     * met adresseerbaar object identificatie '0164010000047847'
     En het adres 'Stadserf_1_Roosendaal'
@@ -27,42 +21,40 @@ Functionaliteit: Gebeurtenissen bevragen
     * verblijft vanaf '14-4-2020' op het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
     En de persoon 'Piet'
     * verblijft vanaf '14-4-2020' op het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
-    #En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
-    #En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
-    #En abonnee 'JZ' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
 
-  Regel: Een abonnee kan niet-gelezen gebeurtenissen chronologisch bevragen
-    De abonnee ontvangt steeds de oudste niet-gelezen gebeurtenis
+  Regel: Een abonnee ontvangt steeds de oudste niet-gelezen gebeurtenis
 
     Scenario: De abonnee heeft nog geen gebeurtenissen gevraagd
       Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
       En de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
       Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
-      Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
+      Dan wordt een 'verhuisd.intergemeentelijk' gebeurtenis geleverd met de volgende data
       * het burgerservicenummer van 'Jan'
       * de vanaf datum van de opgave van verhuizing van 'Jan'
 
     Scenario: De abonnee vraagt ongelezen gebeurtenissen en er zijn meerdere gebeurtenissen
       Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
       En de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
       En de aangifte van adreswijziging van 'Piet' is verwerkt
       * verblijft vanaf '2-9-2025' op het adres 'Stadserf_1_Roosendaal'
       Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
-      Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
+      Dan wordt een 'verhuisd.intergemeentelijk' gebeurtenis geleverd met de volgende data
       * het burgerservicenummer van 'Jan'
       * de vanaf datum van de opgave van verhuizing van 'Jan'
 
     Scenario: De abonnee vraagt ongelezen gebeurtenissen, er zijn meerdere gebeurtenissen en de eerste gebeurtenis is al gelezen
       Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
       En de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
       En de aangifte van adreswijziging van 'Piet' is verwerkt
       * verblijft vanaf '2-9-2025' op het adres 'Stadserf_1_Roosendaal'
       En een niet-gelezen gebeurtenis is gevraagd door abonnee 'SZW'
       Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
-      Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
+      Dan wordt een 'verhuisd.intergemeentelijk' gebeurtenis geleverd met de volgende data
       * het burgerservicenummer van 'Piet'
       * de vanaf datum van de opgave van verhuizing van 'Piet'
 
@@ -82,7 +74,7 @@ Functionaliteit: Gebeurtenissen bevragen
     Scenario: De abonnee vraagt ongelezen gebeurtenissen en is niet geabonneerd op de gebeurtenis
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'Belastingen'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan wordt er geen gebeurtenis geleverd
 
     Scenario: De abonnee vraagt ongelezen gebeurtenissen en een is geabonneerd op het gebeurtenistype voor een andere persoon
@@ -108,7 +100,7 @@ Functionaliteit: Gebeurtenissen bevragen
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
       En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
       Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'JZ'
-      Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
+      Dan wordt een 'verhuisd.intergemeentelijk' gebeurtenis geleverd met de volgende data
       * het burgerservicenummer van 'Jan'
       * de vanaf datum van de opgave van verhuizing van 'Jan'
 
@@ -133,62 +125,6 @@ Functionaliteit: Gebeurtenissen bevragen
       Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'WMO'
       Dan is de response '403 Forbidden'
 
-  Regel: Een abonnee kan gebeurtenissen vanaf een bepaald tijdstip als niet-gelezen markeren
-
-    Scenario: De abonnee heeft alle niet-gelezen gebeurtenissen gevraagd en markeert de gebeurtenissen als niet-gelezen vanaf een bepaald moment
-      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
-      En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
-      En vorige week om 9:29 uur is de aangifte van adreswijziging van 'Jan' verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      En vorige week om 9:32 uur is de aangifte van adreswijziging van 'Piet' verwerkt
-      * verblijft vanaf '2-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
-      En abonnee 'SZW' markeert de gebeurtenissen vanaf vorige week om 9:30 uur als niet-gelezen
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
-      Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
-      * het burgerservicenummer van 'Piet'
-      * de vanaf datum van de opgave van verhuizing van 'Piet'
-
-  Regel: Een abonnee kan gebeurtenissen na een bepaalde gebeurtenis als niet-gelezen markeren
-
-    Scenario: De abonnee heeft alle niet-gelezen gebeurtenissen gevraagd en markeert de gebeurtenissen als niet-gelezen vanaf een bepaald moment
-      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
-      En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
-      En de aangifte van adreswijziging van 'Jan' is verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      En de aangifte van adreswijziging van 'Piet' is verwerkt
-      * verblijft vanaf '2-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
-      En abonnee 'SZW' markeert de gebeurtenissen na de gebeurtenis 'verhuisd.intergemeentelijk' van 'Jan' als niet-gelezen
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
-      Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
-      * het burgerservicenummer van 'Piet'
-      * de vanaf datum van de opgave van verhuizing van 'Piet'
-
-  Regel: Gebeurtenissen op niet-gelezen zetten geldt alleen voor de abonnee die dit doet
-
-    Scenario: De abonnee heeft alle niet-gelezen gebeurtenissen gevraagd en een andere abonnee van dezelfde afnemer markeert alle gebeurtenissen als niet-gelezen
-      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
-      En abonnee 'JZ' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
-      En vorige week om 9:32 uur is de aangifte van adreswijziging van 'Jan' verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
-      En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'JZ'
-      En abonnee 'SZW' markeert de gebeurtenissen vanaf vorige week om 9:30 uur als niet-gelezen
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'JZ'
-      Dan wordt er geen gebeurtenis geleverd
-
-  Regel: Alleen gebeurtenissen die hebben plaatsgevonden na het zetten van het abonnement kunnen weer ongelezen worden
-    Deze regel is de consequentie van de regel "Een abonnee ontvangt alleen gebeurtenissen die hebben plaatsgevonden na het plaatsen van het abonnement daarop"
-
-    Scenario: Gebeurtenissen worden op ongelezen gezet vanaf een moment vóór het zetten van het abonnement
-      Gegeven vorige week om 9:32 uur is de aangifte van adreswijziging van 'Jan' verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
-      En abonnee 'SZW' markeert de gebeurtenissen vanaf vorige week om 9:30 uur als niet-gelezen
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
-      Dan wordt er geen gebeurtenis geleverd
-
   Regel: Gebeurtenissen ouder dan 2 maanden zijn ze niet meer op te vragen
 
     Scenario: De gebeurtenis heeft meer dan 2 maanden geleden plaatsgevonden en de abonnee wil deze nu nog lezen
@@ -197,23 +133,3 @@ Functionaliteit: Gebeurtenissen bevragen
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
       Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan wordt er geen gebeurtenis geleverd
-
-  Regel: Alleen gebeurtenissen van minder dan 2 maanderen geleden kunnen op ongelezen worden gezet
-    Wanneer de vanafdatum ligt voor de oudst beschikbare gebeurtenis, dan worden alle nog wel beschikbare gebeurtenissen op niet-gelezen gezet.
-    Wanneer de opgegeven gebeurtenis niet meer beschikbaar is, dan worden alle nog wel beschikbare gebeurtenissen op niet-gelezen gezet.
-
-    Scenario: De abonnee probeert gebeurtenissen van meer dan 2 maanden geleden op ongelezen te zetten
-      Als abonnee 'SZW' de gebeurtenissen vanaf 4 maanden geleden om 9:30 uur als niet-gelezen markeert
-      Dan is de response '400 Bad Request'
-
-  Regel: Als de abonnee gebeurtenissen op ongelezen wil wetten met een gebeurtenis id die niet bekend is of niet meer beschikbaar is, dan wordt een foutmelding gegeven
-
-    Scenario: De abonnee probeert gebeurtenissen na een gebeurtenis die die bekend is op ongelezen te zetten
-      Als abonnee 'SZW' de gebeurtenissen na de gebeurtenis met id 99999999 als niet-gelezen markeert
-      Dan is de response '400 Bad Request'
-
-    Scenario: De abonnee probeert gebeurtenissen na een gebeurtenis die meer dan 2 maanden geleden heeft plaatsgevonden op ongelezen te zetten
-      Gegeven 3 maanden geleden om 9:32 uur is de aangifte van adreswijziging van 'Jan' verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      Als abonnee 'SZW' markeert de gebeurtenissen na de gebeurtenis 'verhuisd.intergemeentelijk' van 'Jan' als niet-gelezen
-      Dan is de response '400 Bad Request'

--- a/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
+++ b/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
@@ -68,8 +68,7 @@ Functionaliteit: Gebeurtenissen bevragen
       Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan wordt er geen gebeurtenis geleverd
 
-  Regel: Een abonnee krijgt alleen gebeurtenissen waarop hij geabonneerd is
-    De abonnee krijgt alleen een gebeurtenis wanneer hij een abonnement heeft op het type gebeurtenis voor de persoon waarop de gebeurtenis heeft plaatsgevonden
+  Regel: Een abonnee krijgt alleen een gebeurtenis wanneer hij een abonnement heeft op het type gebeurtenis voor de persoon waarop de gebeurtenis heeft plaatsgevonden
 
     Scenario: De abonnee vraagt ongelezen gebeurtenissen en is niet geabonneerd op de gebeurtenis
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
@@ -105,6 +104,8 @@ Functionaliteit: Gebeurtenissen bevragen
       * de vanaf datum van de opgave van verhuizing van 'Jan'
 
   Regel: Een abonnee ontvangt alleen gebeurtenissen die hebben plaatsgevonden na het plaatsen van het abonnement daarop
+    Een abonnee zet een abonnement op het moment dat doelbinding op het ontvangen van de gebeurtenis voor de persoon ontstaat
+    en heeft dus geen doelbinding voor het ontvangen van deze gebeurtenissen voor deze persoon die daarvóór hebben plaatsgevonden.
 
     Scenario: De gebeurtenis heeft plaatsgevonden vóór het abonement is gezet
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
@@ -115,13 +116,13 @@ Functionaliteit: Gebeurtenissen bevragen
 
   Regel: Bij het vragen van niet-gelezen gebeurtenissen is het opgeven van de abonnee verplicht
 
-    Scenario: Afnemer is geabonneerd op een gebeurtenis voor een abonnee en vraagt ongelezen gebeurtenissen zonder de abonnee op te geven
+    Scenario: Afnemer vraagt ongelezen gebeurtenissen zonder de abonnee op te geven
       Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo'
       Dan is de response '400 Bad Request'
 
-  Regel: Alleen een geregistreerde abonnee mag gebeurtenissen bevragen
+  Regel: Alleen een abonnee mag gebeurtenissen bevragen
 
-    Scenario: Afnemer is geabonneerd op een gebeurtenis voor een abonnee en vraagt ongelezen gebeurtenissen met een niet-geregistreerde abonnee
+    Scenario: Afnemer vraagt ongelezen gebeurtenissen en vult bij abonnee iets anders in dan een abonnee
       Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'WMO'
       Dan is de response '403 Forbidden'
 

--- a/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
+++ b/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
@@ -90,14 +90,14 @@ Functionaliteit: Gebeurtenissen bevragen
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
       Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'WMO'
-      En is de response '403 Forbidden'
+      Dan is de response '403 Forbidden' met de volgende velden
       * heeft het detail veld de tekst 'Uw verzoek kan niet worden uitgevoerd omdat u niet als abonnee geregistreerd bent.'
 
     Scenario: Afnemer is geabonneerd op een gebeurtenis voor een abonnee en vraagt ongelezen gebeurtenissen zonder de abonnee op te geven
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
       Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo'
-      En is de response '400 Bad Request'
+      Dan is de response '400 Bad Request' met de volgende velden
       * 'detail' met tekst 'De foutieve parameter(s) zijn: abonnee.'
       * een 'invalidParams' met de volgende gegevens
         | code     | name    | reason                  |

--- a/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
+++ b/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
@@ -1,93 +1,90 @@
 # language: nl
 Functionaliteit: Gebeurtenissen bevragen
   Als consumer van BRP Gebeurtenissen
-  wil ik niet-gelezen gebeurtenissen chronologisch kunnen bevragen
+  wil ik ongelezen gebeurtenissen chronologisch kunnen bevragen
   zodat ik asynchroon de gebeurtenissen waarop ik ben geabonneerd kan verwerken
 
   Als gemeente 
-  wil ik dat mijn interne afnemers zelf eigen abonnementen kunnen hebben en niet-gelezen eigen gebeurtenissen kunnen opvragen
+  wil ik dat mijn interne afnemers zelf eigen abonnementen kunnen hebben en ongelezen eigen gebeurtenissen kunnen opvragen
   zodat ik niet zelf een distributiesysteem hoef te ontwikkelen/inkopen dat binnenkomende gebeurtenissen verdeelt onder mijn interne afnemers
 
   Achtergrond:
-    Gegeven de afnemer 'Hengelo' heeft abonnee 'SZW' geregistreerd
-    En de afnemer 'Hengelo' heeft abonnee 'JZ' geregistreerd
+    Gegeven de afnemer 'Hengelo' heeft abonnees 'SZW en JZ' geregistreerd
     En het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
     * in gemeente 'Hengelo'
-    * met adresseerbaar object identificatie '0164010000047847'
     En het adres 'Stadserf_1_Roosendaal'
     * in gemeente 'Roosendaal'
-    * met adresseerbaar object identificatie '1674010000008508'
-    Gegeven de persoon 'Jan'
-    * verblijft vanaf '14-4-2020' op het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
-    En de persoon 'Piet'
-    * verblijft vanaf '14-4-2020' op het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
+    Gegeven 'Jan en Piet' verblijven vanaf '14-4-2020' op het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
 
-  Regel: Een abonnee ontvangt steeds de oudste niet-gelezen gebeurtenis
+  Regel: Een abonnee ontvangt steeds de oudste ongelezen gebeurtenis
 
     Scenario: De abonnee heeft nog geen gebeurtenissen gevraagd
       Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
       En de aangifte van adreswijziging van 'Jan' is verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Dan wordt de 'verhuisd.intergemeentelijk' gebeurtenis van 'Jan' geleverd
+
+    Scenario: Er zijn meerdere gebeurtenissen dus de abonnee ontvangt de oudste gebeurtenis
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan en Piet'
+      En de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf 3 dagen geleden op het adres 'Stadserf_1_Roosendaal'
+      En de aangifte van adreswijziging van 'Piet' is verwerkt
+      * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Dan wordt de 'verhuisd.intergemeentelijk' gebeurtenis van 'Jan' geleverd
+
+    Scenario: De eerste van meerdere gebeurtenissen is al gelezen dus de abonnee ontvangt de tweede gebeurtenis
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan en Piet'
+      En de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf 3 dagen geleden op het adres 'Stadserf_1_Roosendaal'
+      En de aangifte van adreswijziging van 'Piet' is verwerkt
+      * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
+      En een ongelezen gebeurtenis is gevraagd door abonnee 'SZW'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Dan wordt de 'verhuisd.intergemeentelijk' gebeurtenis van 'Piet' geleverd
+
+  Regel: Een gebeurtenis 'verhuisd.intergemeentelijk' wordt geleverd met het burgerservicenummer van de betreffende persoon en de datum vanaf wanneer deze hier verblijft
+
+    Scenario: De gebeurtenis wordt geleverd met burgerservicenummer en datum vanaf
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan wordt een 'verhuisd.intergemeentelijk' gebeurtenis geleverd met de volgende data
       * het burgerservicenummer van 'Jan'
       * de vanaf datum van de opgave van verhuizing van 'Jan'
 
-    Scenario: De abonnee vraagt ongelezen gebeurtenissen en er zijn meerdere gebeurtenissen
-      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
-      En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
-      En de aangifte van adreswijziging van 'Jan' is verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      En de aangifte van adreswijziging van 'Piet' is verwerkt
-      * verblijft vanaf '2-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
-      Dan wordt een 'verhuisd.intergemeentelijk' gebeurtenis geleverd met de volgende data
-      * het burgerservicenummer van 'Jan'
-      * de vanaf datum van de opgave van verhuizing van 'Jan'
+  Regel: Als er voor de abonnee geen ongelezen gebeurtenissen zijn, krijgt hij een leeg antwoord
 
-    Scenario: De abonnee vraagt ongelezen gebeurtenissen, er zijn meerdere gebeurtenissen en de eerste gebeurtenis is al gelezen
-      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
-      En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
-      En de aangifte van adreswijziging van 'Jan' is verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      En de aangifte van adreswijziging van 'Piet' is verwerkt
-      * verblijft vanaf '2-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      En een niet-gelezen gebeurtenis is gevraagd door abonnee 'SZW'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
-      Dan wordt een 'verhuisd.intergemeentelijk' gebeurtenis geleverd met de volgende data
-      * het burgerservicenummer van 'Piet'
-      * de vanaf datum van de opgave van verhuizing van 'Piet'
-
-  Regel: Als er voor de abonnee geen niet-gelezen gebeurtenissen zijn, krijgt hij een leeg antwoord
-
-    Scenario: De abonnee heeft alle niet-gelezen gebeurtenissen al gevraagd
+    Scenario: De abonnee heeft alle ongelezen gebeurtenissen al gevraagd
       Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
       En de aangifte van adreswijziging van 'Jan' is verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
+      En alle ongelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan wordt er geen gebeurtenis geleverd
 
   Regel: Een abonnee krijgt alleen een gebeurtenis wanneer hij een abonnement heeft op het type gebeurtenis voor de persoon waarop de gebeurtenis heeft plaatsgevonden
 
     Scenario: De abonnee vraagt ongelezen gebeurtenissen en is niet geabonneerd op de gebeurtenis
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan wordt er geen gebeurtenis geleverd
 
     Scenario: De abonnee vraagt ongelezen gebeurtenissen en een is geabonneerd op het gebeurtenistype voor een andere persoon
       Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
       En de aangifte van adreswijziging van 'Jan' is verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan wordt er geen gebeurtenis geleverd
 
     Scenario: De abonnee vraagt ongelezen gebeurtenissen en een is geabonneerd op een ander gebeurtenistype voor de persoon
       Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.naar-buitenland' gebeurtenissen van 'Jan'
       En de aangifte van adreswijziging van 'Jan' is verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan wordt er geen gebeurtenis geleverd
 
   Regel: Meerdere abonnees kunnen dezelfde gebeurtenis ontvangen
@@ -96,12 +93,10 @@ Functionaliteit: Gebeurtenissen bevragen
       Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
       En abonnee 'JZ' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
       En de aangifte van adreswijziging van 'Jan' is verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'JZ'
-      Dan wordt een 'verhuisd.intergemeentelijk' gebeurtenis geleverd met de volgende data
-      * het burgerservicenummer van 'Jan'
-      * de vanaf datum van de opgave van verhuizing van 'Jan'
+      * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
+      En alle ongelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'JZ'
+      Dan wordt de 'verhuisd.intergemeentelijk' gebeurtenis van 'Jan' geleverd
 
   Regel: Een abonnee ontvangt alleen gebeurtenissen die hebben plaatsgevonden na het plaatsen van het abonnement daarop
     Een abonnee zet een abonnement op het moment dat doelbinding op het ontvangen van de gebeurtenis voor de persoon ontstaat
@@ -109,21 +104,21 @@ Functionaliteit: Gebeurtenissen bevragen
 
     Scenario: De gebeurtenis heeft plaatsgevonden vóór het abonement is gezet
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
       En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan wordt er geen gebeurtenis geleverd
 
-  Regel: Bij het vragen van niet-gelezen gebeurtenissen is het opgeven van de abonnee verplicht
+  Regel: Bij het vragen van ongelezen gebeurtenissen is het opgeven van de abonnee verplicht
 
     Scenario: Afnemer vraagt ongelezen gebeurtenissen zonder de abonnee op te geven
-      Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo'
+      Als een ongelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo'
       Dan is de response '400 Bad Request'
 
   Regel: Alleen een abonnee mag gebeurtenissen bevragen
 
     Scenario: Afnemer vraagt ongelezen gebeurtenissen en vult bij abonnee iets anders in dan een abonnee
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'WMO'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'WMO'
       Dan is de response '403 Forbidden'
 
   Regel: Gebeurtenissen ouder dan 2 maanden zijn ze niet meer op te vragen
@@ -131,6 +126,6 @@ Functionaliteit: Gebeurtenissen bevragen
     Scenario: De gebeurtenis heeft meer dan 2 maanden geleden plaatsgevonden en de abonnee wil deze nu nog lezen
       Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
       En 3 maanden geleden om 9:32 uur is de aangifte van adreswijziging van 'Jan' verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      * verblijft vanaf gisteren op het adres 'Stadserf_1_Roosendaal'
+      Als een ongelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan wordt er geen gebeurtenis geleverd

--- a/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
+++ b/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
@@ -14,9 +14,9 @@ Functionaliteit: Gebeurtenissen bevragen
 
   Achtergrond:
     Gegeven de afnemer 'Hengelo'
-    * is geregistreerd als abonnee van BRP API Gebeurtenissen met rol 'SZW'
-    * is geregistreerd als abonnee van BRP API Gebeurtenissen met rol 'JZ'
-    * is geregistreerd als abonnee van BRP API Gebeurtenissen met rol 'Belastingen'
+    * is geregistreerd als abonnee 'SZW' van BRP API Gebeurtenissen
+    * is geregistreerd als abonnee 'JZ' van BRP API Gebeurtenissen
+    * is geregistreerd als abonnee 'Belastingen' van BRP API Gebeurtenissen
     Gegeven het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
     * in gemeente 'Hengelo'
     * met adresseerbaar object identificatie '0164010000047847'
@@ -25,77 +25,101 @@ Functionaliteit: Gebeurtenissen bevragen
     * met adresseerbaar object identificatie '1674010000008508'
     Gegeven de persoon 'Jan'
     * verblijft vanaf '14-4-2020' op het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
-    En afnemer 'Hengelo' met de rol 'SZW' is geabonneerd op 'verhuisd.intergemeentelijk' gebeurtenissen van de persoon 'Jan'
-    En afnemer 'Hengelo' met de rol 'JZ' is geabonneerd op 'verhuisd.intergemeentelijk' gebeurtenissen van de persoon 'Jan'
+    En de persoon 'Piet'
+    * verblijft vanaf '14-4-2020' op het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
+    En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+    En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
+    En abonnee 'JZ' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
 
-  Regel: Een afnemer kan niet-gelezen gebeurtenissen waarop hij is geabonneerd chronologisch bevragen
+  Regel: Een abonnee kan niet-gelezen gebeurtenissen waarop hij is geabonneerd chronologisch bevragen
 
-    Scenario: Afnemer heeft nog geen gebeurtenissen gevraagd
+    Scenario: De abonnee heeft nog geen gebeurtenissen gevraagd
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo' met rol 'SZW'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
-      * het A-nummer van 'Jan'
+      * het burgerservicenummer van 'Jan'
       * de vanaf datum van de opgave van verhuizing van 'Jan'
-      * de adresseerbaar object identificatie van het adres 'Stadserf_1_Roosendaal'
 
-    Scenario: Afnemer heeft alle niet-gelezen gebeurtenissen al gevraagd met deze rol en nog niet met een andere rol
+    Scenario: De abonnee vraagt ongelezen gebeurtenissen en er zijn meerdere gebeurtenissen
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      En alle niet-gelezen gebeurtenissen zijn gevraagd door afnemer 'Hengelo' met rol 'SZW'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo' met rol 'SZW'
+      En de aangifte van adreswijziging van 'Piet' is verwerkt
+      * verblijft vanaf '2-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
+      * het burgerservicenummer van 'Jan'
+      * de vanaf datum van de opgave van verhuizing van 'Jan'
+
+    Scenario: De abonnee vraagt ongelezen gebeurtenissen, er zijn meerdere gebeurtenissen en de eerste gebeurtenis is al gelezen
+      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En de aangifte van adreswijziging van 'Piet' is verwerkt
+      * verblijft vanaf '2-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En een niet-gelezen gebeurtenis is gevraagd door abonnee 'SZW'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
+      * het burgerservicenummer van 'Piet'
+      * de vanaf datum van de opgave van verhuizing van 'Piet'
+
+    Scenario: De abonnee heeft alle niet-gelezen gebeurtenissen al gevraagd en nog niet met een andere abonnee van dezelfde afnemer
+      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan wordt er geen gebeurtenis geleverd
 
-    Scenario: Afnemer heeft alle niet-gelezen gebeurtenissen al gevraagd met een rol en vraagt ongelezen gebeurtenissen met een andere rol
+    Scenario: De abonnee vraagt ongelezen gebeurtenissen en heeft alle niet-gelezen gebeurtenissen al gevraagd met een andere abonnee van dezelfde afnemer
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      En alle niet-gelezen gebeurtenissen zijn gevraagd door afnemer 'Hengelo' met rol 'SZW'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo' met rol 'JZ'
+      En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'JZ'
       Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
-      * het A-nummer van 'Jan'
+      * het burgerservicenummer van 'Jan'
       * de vanaf datum van de opgave van verhuizing van 'Jan'
-      * de adresseerbaar object identificatie van het adres 'Stadserf_1_Roosendaal'
 
-    Scenario: Afnemer is geabonneerd op een gebeurtenis voor een rol en vraagt ongelezen gebeurtenissen met een andere rol
+    Scenario: De abonnee vraagt ongelezen gebeurtenissen en een andere abonnee van dezelfde afnemer is geabonneerd op de gebeurtenis
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo' met rol 'Belastingen'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'Belastingen'
       Dan wordt er geen gebeurtenis geleverd
 
-  Regel: Een afnemer kan alleen niet-gelezen gebeurtenissen bevragen met een rol die als abonnee geregistreerd is
+  Regel: Een afnemer kan alleen niet-gelezen gebeurtenissen bevragen met een abonnee die al geregistreerd is
 
-    Scenario: Afnemer is geabonneerd op een gebeurtenis voor een rol en vraagt ongelezen gebeurtenissen met een niet-geregistreerde rol
+    Scenario: Afnemer is geabonneerd op een gebeurtenis voor een abonnee en vraagt ongelezen gebeurtenissen met een niet-geregistreerde abonnee
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo' met rol 'WMO'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'WMO'
       En is de response '403 Forbidden'
       * heeft het detail veld de tekst 'Uw verzoek kan niet worden uitgevoerd omdat u niet als abonnee geregistreerd bent.'
 
-    Scenario: Afnemer is geabonneerd op een gebeurtenis voor een rol en vraagt ongelezen gebeurtenissen zonder een rol op te geven
+    Scenario: Afnemer is geabonneerd op een gebeurtenis voor een abonnee en vraagt ongelezen gebeurtenissen zonder de abonnee op te geven
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
       Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo'
-      En is de response '403 Forbidden'
-      * heeft het detail veld de tekst 'Uw verzoek kan niet worden uitgevoerd omdat u niet als abonnee geregistreerd bent.'
+      En is de response '400 Bad Request'
+      * 'detail' met tekst 'De foutieve parameter(s) zijn: abonnee.'
+      * een 'invalidParams' met de volgende gegevens
+        | code     | name    | reason                  |
+        | required | abonnee | Parameter is verplicht. |
 
-  Regel: Een afnemer kan alle gebeurtenissen als niet-gelezen markeren
+  Regel: Een abonnee kan alle gebeurtenissen als niet-gelezen markeren
 
-    Scenario: Afnemer heeft alle niet-gelezen gebeurtenissen gevraagd en markeert alle gebeurtenissen als niet-gelezen
+    Scenario: De abonnee heeft alle niet-gelezen gebeurtenissen gevraagd en markeert alle gebeurtenissen als niet-gelezen
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      En alle niet-gelezen gebeurtenissen zijn gevraagd door afnemer 'Hengelo' met rol 'SZW'
-      En afnemer 'Hengelo' met rol 'SZW' markeert al zijn gebeurtenissen als niet-gelezen
-      Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo' met rol 'SZW'
+      En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
+      En abonnee 'SZW' markeert al zijn gebeurtenissen als niet-gelezen
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
-      * het A-nummer van 'Jan'
+      * het burgerservicenummer van 'Jan'
       * de vanaf datum van de opgave van verhuizing van 'Jan'
-      * de adresseerbaar object identificatie van het adres 'Stadserf_1_Roosendaal'
 
-    Scenario: Afnemer met een rol heeft alle niet-gelezen gebeurtenissen gevraagd en dezelfde afnemer met een andere rol markeert alle gebeurtenissen als niet-gelezen
+    Scenario: De abonnee heeft alle niet-gelezen gebeurtenissen gevraagd en een andere abonnee van dezelfde afnemer markeert alle gebeurtenissen als niet-gelezen
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      En alle niet-gelezen gebeurtenissen zijn gevraagd door afnemer 'Hengelo' met rol 'SZW'
-      En alle niet-gelezen gebeurtenissen zijn gevraagd door afnemer 'Hengelo' met rol 'JZ'
-      En afnemer 'Hengelo' met rol 'JZ' markeert al zijn gebeurtenissen als niet-gelezen
-      Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo' met rol 'SZW'
+      En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
+      En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'JZ'
+      En abonnee 'JZ' markeert al zijn gebeurtenissen als niet-gelezen
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan wordt er geen gebeurtenis geleverd

--- a/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
+++ b/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
@@ -1,0 +1,101 @@
+# language: nl
+Functionaliteit: Gebeurtenissen bevragen
+  Als consumer van BRP Gebeurtenissen
+  wil ik niet-gelezen gebeurtenissen chronologisch kunnen bevragen
+  zodat ik asynchroon de gebeurtenissen waarop ik ben geabonneerd kan verwerken
+
+  Als consumer van BRP Gebeurtenissen
+  wil ik gebeurtenissen als niet-gelezen kunnen markeren
+  zodat ik de gebeurtenissen opnieuw kan verwerken
+
+  Als gemeente 
+  wil ik dat mijn interne afnemers zelf eigen abonnementen kunnen hebben en niet-gelezen eigen gebeurtenissen kunnen opvragen
+  zodat ik niet zelf een distributiesysteem hoef te ontwikkelen/inkopen dat binnenkomende gebeurtenissen verdeelt onder mijn interne afnemers
+
+  Achtergrond:
+    Gegeven de afnemer 'Hengelo'
+    * is geregistreerd als abonnee van BRP API Gebeurtenissen met rol 'SZW'
+    * is geregistreerd als abonnee van BRP API Gebeurtenissen met rol 'JZ'
+    * is geregistreerd als abonnee van BRP API Gebeurtenissen met rol 'Belastingen'
+    Gegeven het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
+    * in gemeente 'Hengelo'
+    * met adresseerbaar object identificatie '0164010000047847'
+    En het adres 'Stadserf_1_Roosendaal'
+    * in gemeente 'Roosendaal'
+    * met adresseerbaar object identificatie '1674010000008508'
+    Gegeven de persoon 'Jan'
+    * verblijft vanaf '14-4-2020' op het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
+    En afnemer 'Hengelo' met de rol 'SZW' is geabonneerd op 'verhuisd.intergemeentelijk' gebeurtenissen van de persoon 'Jan'
+    En afnemer 'Hengelo' met de rol 'JZ' is geabonneerd op 'verhuisd.intergemeentelijk' gebeurtenissen van de persoon 'Jan'
+
+  Regel: Een afnemer kan niet-gelezen gebeurtenissen waarop hij is geabonneerd chronologisch bevragen
+
+    Scenario: Afnemer heeft nog geen gebeurtenissen gevraagd
+      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo' met rol 'SZW'
+      Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
+      * het A-nummer van 'Jan'
+      * de vanaf datum van de opgave van verhuizing van 'Jan'
+      * de adresseerbaar object identificatie van het adres 'Stadserf_1_Roosendaal'
+
+    Scenario: Afnemer heeft alle niet-gelezen gebeurtenissen al gevraagd met deze rol en nog niet met een andere rol
+      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En alle niet-gelezen gebeurtenissen zijn gevraagd door afnemer 'Hengelo' met rol 'SZW'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo' met rol 'SZW'
+      Dan wordt er geen gebeurtenis geleverd
+
+    Scenario: Afnemer heeft alle niet-gelezen gebeurtenissen al gevraagd met een rol en vraagt ongelezen gebeurtenissen met een andere rol
+      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En alle niet-gelezen gebeurtenissen zijn gevraagd door afnemer 'Hengelo' met rol 'SZW'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo' met rol 'JZ'
+      Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
+      * het A-nummer van 'Jan'
+      * de vanaf datum van de opgave van verhuizing van 'Jan'
+      * de adresseerbaar object identificatie van het adres 'Stadserf_1_Roosendaal'
+
+    Scenario: Afnemer is geabonneerd op een gebeurtenis voor een rol en vraagt ongelezen gebeurtenissen met een andere rol
+      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo' met rol 'Belastingen'
+      Dan wordt er geen gebeurtenis geleverd
+
+  Regel: Een afnemer kan alleen niet-gelezen gebeurtenissen bevragen met een rol die als abonnee geregistreerd is
+
+    Scenario: Afnemer is geabonneerd op een gebeurtenis voor een rol en vraagt ongelezen gebeurtenissen met een niet-geregistreerde rol
+      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo' met rol 'WMO'
+      En is de response '403 Forbidden'
+      * heeft het detail veld de tekst 'Uw verzoek kan niet worden uitgevoerd omdat u niet als abonnee geregistreerd bent.'
+
+    Scenario: Afnemer is geabonneerd op een gebeurtenis voor een rol en vraagt ongelezen gebeurtenissen zonder een rol op te geven
+      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo'
+      En is de response '403 Forbidden'
+      * heeft het detail veld de tekst 'Uw verzoek kan niet worden uitgevoerd omdat u niet als abonnee geregistreerd bent.'
+
+  Regel: Een afnemer kan alle gebeurtenissen als niet-gelezen markeren
+
+    Scenario: Afnemer heeft alle niet-gelezen gebeurtenissen gevraagd en markeert alle gebeurtenissen als niet-gelezen
+      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En alle niet-gelezen gebeurtenissen zijn gevraagd door afnemer 'Hengelo' met rol 'SZW'
+      En afnemer 'Hengelo' met rol 'SZW' markeert al zijn gebeurtenissen als niet-gelezen
+      Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo' met rol 'SZW'
+      Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
+      * het A-nummer van 'Jan'
+      * de vanaf datum van de opgave van verhuizing van 'Jan'
+      * de adresseerbaar object identificatie van het adres 'Stadserf_1_Roosendaal'
+
+    Scenario: Afnemer met een rol heeft alle niet-gelezen gebeurtenissen gevraagd en dezelfde afnemer met een andere rol markeert alle gebeurtenissen als niet-gelezen
+      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En alle niet-gelezen gebeurtenissen zijn gevraagd door afnemer 'Hengelo' met rol 'SZW'
+      En alle niet-gelezen gebeurtenissen zijn gevraagd door afnemer 'Hengelo' met rol 'JZ'
+      En afnemer 'Hengelo' met rol 'JZ' markeert al zijn gebeurtenissen als niet-gelezen
+      Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo' met rol 'SZW'
+      Dan wordt er geen gebeurtenis geleverd

--- a/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
+++ b/features/gebeurtenis-service/gebeurtenissen-bevragen.feature
@@ -27,14 +27,16 @@ Functionaliteit: Gebeurtenissen bevragen
     * verblijft vanaf '14-4-2020' op het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
     En de persoon 'Piet'
     * verblijft vanaf '14-4-2020' op het adres 'Burgemeester_Van_Der_Dussenplein_1_Hengelo'
-    En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
-    En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
-    En abonnee 'JZ' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+    #En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+    #En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
+    #En abonnee 'JZ' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
 
-  Regel: Een abonnee kan niet-gelezen gebeurtenissen waarop hij is geabonneerd chronologisch bevragen
+  Regel: Een abonnee kan niet-gelezen gebeurtenissen chronologisch bevragen
+    De abonnee ontvangt steeds de oudste niet-gelezen gebeurtenis
 
     Scenario: De abonnee heeft nog geen gebeurtenissen gevraagd
-      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
       Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
@@ -42,7 +44,8 @@ Functionaliteit: Gebeurtenissen bevragen
       * de vanaf datum van de opgave van verhuizing van 'Jan'
 
     Scenario: De abonnee vraagt ongelezen gebeurtenissen en er zijn meerdere gebeurtenissen
-      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
       En de aangifte van adreswijziging van 'Piet' is verwerkt
       * verblijft vanaf '2-9-2025' op het adres 'Stadserf_1_Roosendaal'
@@ -52,7 +55,8 @@ Functionaliteit: Gebeurtenissen bevragen
       * de vanaf datum van de opgave van verhuizing van 'Jan'
 
     Scenario: De abonnee vraagt ongelezen gebeurtenissen, er zijn meerdere gebeurtenissen en de eerste gebeurtenis is al gelezen
-      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
       En de aangifte van adreswijziging van 'Piet' is verwerkt
       * verblijft vanaf '2-9-2025' op het adres 'Stadserf_1_Roosendaal'
@@ -62,15 +66,45 @@ Functionaliteit: Gebeurtenissen bevragen
       * het burgerservicenummer van 'Piet'
       * de vanaf datum van de opgave van verhuizing van 'Piet'
 
-    Scenario: De abonnee heeft alle niet-gelezen gebeurtenissen al gevraagd en nog niet met een andere abonnee van dezelfde afnemer
-      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+  Regel: Als er voor de abonnee geen niet-gelezen gebeurtenissen zijn, krijgt hij een leeg antwoord
+
+    Scenario: De abonnee heeft alle niet-gelezen gebeurtenissen al gevraagd
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
       En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
       Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan wordt er geen gebeurtenis geleverd
 
-    Scenario: De abonnee vraagt ongelezen gebeurtenissen en heeft alle niet-gelezen gebeurtenissen al gevraagd met een andere abonnee van dezelfde afnemer
+  Regel: Een abonnee krijgt alleen gebeurtenissen waarop hij geabonneerd is
+    De abonnee krijgt alleen een gebeurtenis wanneer hij een abonnement heeft op het type gebeurtenis voor de persoon waarop de gebeurtenis heeft plaatsgevonden
+
+    Scenario: De abonnee vraagt ongelezen gebeurtenissen en is niet geabonneerd op de gebeurtenis
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'Belastingen'
+      Dan wordt er geen gebeurtenis geleverd
+
+    Scenario: De abonnee vraagt ongelezen gebeurtenissen en een is geabonneerd op het gebeurtenistype voor een andere persoon
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
+      En de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Dan wordt er geen gebeurtenis geleverd
+
+    Scenario: De abonnee vraagt ongelezen gebeurtenissen en een is geabonneerd op een ander gebeurtenistype voor de persoon
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.naar-buitenland' gebeurtenissen van 'Jan'
+      En de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Dan wordt er geen gebeurtenis geleverd
+
+  Regel: Meerdere abonnees kunnen dezelfde gebeurtenis ontvangen
+
+    Scenario: De abonnee vraagt ongelezen gebeurtenissen en een andere abonnee heeft de gebeurtenis al gevraagd
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En abonnee 'JZ' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
       En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
       Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'JZ'
@@ -78,48 +112,108 @@ Functionaliteit: Gebeurtenissen bevragen
       * het burgerservicenummer van 'Jan'
       * de vanaf datum van de opgave van verhuizing van 'Jan'
 
-    Scenario: De abonnee vraagt ongelezen gebeurtenissen en een andere abonnee van dezelfde afnemer is geabonneerd op de gebeurtenis
+  Regel: Een abonnee ontvangt alleen gebeurtenissen die hebben plaatsgevonden na het plaatsen van het abonnement daarop
+
+    Scenario: De gebeurtenis heeft plaatsgevonden vóór het abonement is gezet
       Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'Belastingen'
+      En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan wordt er geen gebeurtenis geleverd
 
-  Regel: Een afnemer kan alleen niet-gelezen gebeurtenissen bevragen met een abonnee die al geregistreerd is
-
-    Scenario: Afnemer is geabonneerd op een gebeurtenis voor een abonnee en vraagt ongelezen gebeurtenissen met een niet-geregistreerde abonnee
-      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'WMO'
-      Dan is de response '403 Forbidden' met de volgende velden
-      * heeft het detail veld de tekst 'Uw verzoek kan niet worden uitgevoerd omdat u niet als abonnee geregistreerd bent.'
+  Regel: Bij het vragen van niet-gelezen gebeurtenissen is het opgeven van de abonnee verplicht
 
     Scenario: Afnemer is geabonneerd op een gebeurtenis voor een abonnee en vraagt ongelezen gebeurtenissen zonder de abonnee op te geven
-      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
       Als een niet-gelezen gebeurtenis wordt gevraagd door afnemer 'Hengelo'
-      Dan is de response '400 Bad Request' met de volgende velden
-      * 'detail' met tekst 'De foutieve parameter(s) zijn: abonnee.'
-      * een 'invalidParams' met de volgende gegevens
-        | code     | name    | reason                  |
-        | required | abonnee | Parameter is verplicht. |
+      Dan is de response '400 Bad Request'
 
-  Regel: Een abonnee kan alle gebeurtenissen als niet-gelezen markeren
+  Regel: Alleen een geregistreerde abonnee mag gebeurtenissen bevragen
 
-    Scenario: De abonnee heeft alle niet-gelezen gebeurtenissen gevraagd en markeert alle gebeurtenissen als niet-gelezen
-      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+    Scenario: Afnemer is geabonneerd op een gebeurtenis voor een abonnee en vraagt ongelezen gebeurtenissen met een niet-geregistreerde abonnee
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'WMO'
+      Dan is de response '403 Forbidden'
+
+  Regel: Een abonnee kan gebeurtenissen vanaf een bepaald tijdstip als niet-gelezen markeren
+
+    Scenario: De abonnee heeft alle niet-gelezen gebeurtenissen gevraagd en markeert de gebeurtenissen als niet-gelezen vanaf een bepaald moment
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
+      En vorige week om 9:29 uur is de aangifte van adreswijziging van 'Jan' verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En vorige week om 9:32 uur is de aangifte van adreswijziging van 'Piet' verwerkt
+      * verblijft vanaf '2-9-2025' op het adres 'Stadserf_1_Roosendaal'
       En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
-      En abonnee 'SZW' markeert al zijn gebeurtenissen als niet-gelezen
+      En abonnee 'SZW' markeert de gebeurtenissen vanaf vorige week om 9:30 uur als niet-gelezen
       Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
-      * het burgerservicenummer van 'Jan'
-      * de vanaf datum van de opgave van verhuizing van 'Jan'
+      * het burgerservicenummer van 'Piet'
+      * de vanaf datum van de opgave van verhuizing van 'Piet'
+
+  Regel: Een abonnee kan gebeurtenissen na een bepaalde gebeurtenis als niet-gelezen markeren
+
+    Scenario: De abonnee heeft alle niet-gelezen gebeurtenissen gevraagd en markeert de gebeurtenissen als niet-gelezen vanaf een bepaald moment
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
+      En de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En de aangifte van adreswijziging van 'Piet' is verwerkt
+      * verblijft vanaf '2-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
+      En abonnee 'SZW' markeert de gebeurtenissen na de gebeurtenis 'verhuisd.intergemeentelijk' van 'Jan' als niet-gelezen
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Dan is een 'verhuisd.intergemeentelijk' gebeurtenis gepubliceerd met de volgende data
+      * het burgerservicenummer van 'Piet'
+      * de vanaf datum van de opgave van verhuizing van 'Piet'
+
+  Regel: Gebeurtenissen op niet-gelezen zetten geldt alleen voor de abonnee die dit doet
 
     Scenario: De abonnee heeft alle niet-gelezen gebeurtenissen gevraagd en een andere abonnee van dezelfde afnemer markeert alle gebeurtenissen als niet-gelezen
-      Gegeven de aangifte van adreswijziging van 'Jan' is verwerkt
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En abonnee 'JZ' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En vorige week om 9:32 uur is de aangifte van adreswijziging van 'Jan' verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
       En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
       En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'JZ'
-      En abonnee 'JZ' markeert al zijn gebeurtenissen als niet-gelezen
+      En abonnee 'SZW' markeert de gebeurtenissen vanaf vorige week om 9:30 uur als niet-gelezen
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'JZ'
+      Dan wordt er geen gebeurtenis geleverd
+
+  Regel: Alleen gebeurtenissen die hebben plaatsgevonden na het zetten van het abonnement kunnen weer ongelezen worden
+    Deze regel is de consequentie van de regel "Een abonnee ontvangt alleen gebeurtenissen die hebben plaatsgevonden na het plaatsen van het abonnement daarop"
+
+    Scenario: Gebeurtenissen worden op ongelezen gezet vanaf een moment vóór het zetten van het abonnement
+      Gegeven vorige week om 9:32 uur is de aangifte van adreswijziging van 'Jan' verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En abonnee 'SZW' markeert de gebeurtenissen vanaf vorige week om 9:30 uur als niet-gelezen
       Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
       Dan wordt er geen gebeurtenis geleverd
+
+  Regel: Gebeurtenissen ouder dan 2 maanden zijn ze niet meer op te vragen
+
+    Scenario: De gebeurtenis heeft meer dan 2 maanden geleden plaatsgevonden en de abonnee wil deze nu nog lezen
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En 3 maanden geleden om 9:32 uur is de aangifte van adreswijziging van 'Jan' verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Dan wordt er geen gebeurtenis geleverd
+
+  Regel: Alleen gebeurtenissen van minder dan 2 maanderen geleden kunnen op ongelezen worden gezet
+    Wanneer de vanafdatum ligt voor de oudst beschikbare gebeurtenis, dan worden alle nog wel beschikbare gebeurtenissen op niet-gelezen gezet.
+    Wanneer de opgegeven gebeurtenis niet meer beschikbaar is, dan worden alle nog wel beschikbare gebeurtenissen op niet-gelezen gezet.
+
+    Scenario: De abonnee probeert gebeurtenissen van meer dan 2 maanden geleden op ongelezen te zetten
+      Als abonnee 'SZW' de gebeurtenissen vanaf 4 maanden geleden om 9:30 uur als niet-gelezen markeert
+      Dan is de response '400 Bad Request'
+
+  Regel: Als de abonnee gebeurtenissen op ongelezen wil wetten met een gebeurtenis id die niet bekend is of niet meer beschikbaar is, dan wordt een foutmelding gegeven
+
+    Scenario: De abonnee probeert gebeurtenissen na een gebeurtenis die die bekend is op ongelezen te zetten
+      Als abonnee 'SZW' de gebeurtenissen na de gebeurtenis met id 99999999 als niet-gelezen markeert
+      Dan is de response '400 Bad Request'
+
+    Scenario: De abonnee probeert gebeurtenissen na een gebeurtenis die meer dan 2 maanden geleden heeft plaatsgevonden op ongelezen te zetten
+      Gegeven 3 maanden geleden om 9:32 uur is de aangifte van adreswijziging van 'Jan' verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      Als abonnee 'SZW' markeert de gebeurtenissen na de gebeurtenis 'verhuisd.intergemeentelijk' van 'Jan' als niet-gelezen
+      Dan is de response '400 Bad Request'

--- a/features/gebeurtenis-service/gebeurtenissen-ongelezen-zetten.feature
+++ b/features/gebeurtenis-service/gebeurtenissen-ongelezen-zetten.feature
@@ -1,0 +1,81 @@
+# language: nl
+Functionaliteit: Gebeurtenissen opnieuw lezen
+  Als consumer van BRP Gebeurtenissen
+  wil ik gebeurtenissen als niet-gelezen kunnen markeren
+  zodat ik de gebeurtenissen opnieuw kan verwerken
+
+  Regel: Een abonnee kan gebeurtenissen vanaf een bepaald tijdstip als niet-gelezen markeren
+
+    Scenario: De abonnee heeft alle niet-gelezen gebeurtenissen gevraagd en markeert de gebeurtenissen als niet-gelezen vanaf een bepaald moment
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
+      En vorige week om 9:29 uur is de aangifte van adreswijziging van 'Jan' verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En vorige week om 9:32 uur is de aangifte van adreswijziging van 'Piet' verwerkt
+      * verblijft vanaf '2-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
+      En abonnee 'SZW' markeert de gebeurtenissen vanaf vorige week om 9:30 uur als niet-gelezen
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Dan wordt een 'verhuisd.intergemeentelijk' gebeurtenis geleverd met de volgende data
+      * het burgerservicenummer van 'Piet'
+      * de vanaf datum van de opgave van verhuizing van 'Piet'
+
+  Regel: Een abonnee kan gebeurtenissen na een bepaalde gebeurtenis als niet-gelezen markeren
+
+    Scenario: De abonnee heeft alle niet-gelezen gebeurtenissen gevraagd en markeert de gebeurtenissen als niet-gelezen vanaf een bepaald moment
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Piet'
+      En de aangifte van adreswijziging van 'Jan' is verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En de aangifte van adreswijziging van 'Piet' is verwerkt
+      * verblijft vanaf '2-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
+      En abonnee 'SZW' markeert de gebeurtenissen na de gebeurtenis 'verhuisd.intergemeentelijk' van 'Jan' als niet-gelezen
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Dan wordt een 'verhuisd.intergemeentelijk' gebeurtenis geleverd met de volgende data
+      * het burgerservicenummer van 'Piet'
+      * de vanaf datum van de opgave van verhuizing van 'Piet'
+
+  Regel: Gebeurtenissen op niet-gelezen zetten geldt alleen voor de abonnee die dit doet
+
+    Scenario: De abonnee heeft alle niet-gelezen gebeurtenissen gevraagd en een andere abonnee van dezelfde afnemer markeert alle gebeurtenissen als niet-gelezen
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En abonnee 'JZ' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En vorige week om 9:32 uur is de aangifte van adreswijziging van 'Jan' verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'SZW'
+      En alle niet-gelezen gebeurtenissen zijn gevraagd door abonnee 'JZ'
+      En abonnee 'SZW' markeert de gebeurtenissen vanaf vorige week om 9:30 uur als niet-gelezen
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'JZ'
+      Dan wordt er geen gebeurtenis geleverd
+
+  Regel: Alleen gebeurtenissen die hebben plaatsgevonden na het zetten van het abonnement kunnen weer ongelezen worden
+    Deze regel is de consequentie van de regel "Een abonnee ontvangt alleen gebeurtenissen die hebben plaatsgevonden na het plaatsen van het abonnement daarop"
+
+    Scenario: Gebeurtenissen worden op ongelezen gezet vanaf een moment vóór het zetten van het abonnement
+      Gegeven vorige week om 9:32 uur is de aangifte van adreswijziging van 'Jan' verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En abonnee 'SZW' markeert de gebeurtenissen vanaf vorige week om 9:30 uur als niet-gelezen
+      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
+      Dan wordt er geen gebeurtenis geleverd
+
+  Regel: Alleen gebeurtenissen van minder dan 2 maanderen geleden kunnen op ongelezen worden gezet
+    Wanneer de vanafdatum ligt voor de oudst beschikbare gebeurtenis, dan worden alle nog wel beschikbare gebeurtenissen op niet-gelezen gezet.
+    Wanneer de opgegeven gebeurtenis niet meer beschikbaar is, dan worden alle nog wel beschikbare gebeurtenissen op niet-gelezen gezet.
+
+    Scenario: De abonnee probeert gebeurtenissen van meer dan 2 maanden geleden op ongelezen te zetten
+      Als abonnee 'SZW' de gebeurtenissen vanaf 4 maanden geleden om 9:30 uur als niet-gelezen markeert
+      Dan is de response '400 Bad Request'
+
+  Regel: Als de abonnee gebeurtenissen op ongelezen wil zetten met een gebeurtenis id die niet bekend is of niet meer beschikbaar is, dan wordt een foutmelding gegeven
+
+    Scenario: De abonnee probeert gebeurtenissen na een gebeurtenis die die bekend is op ongelezen te zetten
+      Als abonnee 'SZW' de gebeurtenissen na de gebeurtenis met id 99999999 als niet-gelezen markeert
+      Dan is de response '400 Bad Request'
+
+    Scenario: De abonnee probeert gebeurtenissen na een gebeurtenis die meer dan 2 maanden geleden heeft plaatsgevonden op ongelezen te zetten
+      Gegeven 3 maanden geleden om 9:32 uur is de aangifte van adreswijziging van 'Jan' verwerkt
+      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
+      Als abonnee 'SZW' markeert de gebeurtenissen na de gebeurtenis 'verhuisd.intergemeentelijk' van 'Jan' als niet-gelezen
+      Dan is de response '400 Bad Request'

--- a/features/gebeurtenis-service/gebeurtenissen-ongelezen-zetten.feature
+++ b/features/gebeurtenis-service/gebeurtenissen-ongelezen-zetten.feature
@@ -49,33 +49,35 @@ Functionaliteit: Gebeurtenissen opnieuw lezen
       Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'JZ'
       Dan wordt er geen gebeurtenis geleverd
 
-  Regel: Alleen gebeurtenissen die hebben plaatsgevonden na het zetten van het abonnement kunnen weer ongelezen worden
+  Regel: Alleen gebeurtenissen die hebben plaatsgevonden na het zetten van het abonnement mogen op ongelezen worden gezet
     Deze regel is de consequentie van de regel "Een abonnee ontvangt alleen gebeurtenissen die hebben plaatsgevonden na het plaatsen van het abonnement daarop"
 
-    Scenario: Gebeurtenissen worden op ongelezen gezet vanaf een moment vóór het zetten van het abonnement
-      Gegeven vorige week om 9:32 uur is de aangifte van adreswijziging van 'Jan' verwerkt
-      * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      En abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
-      En abonnee 'SZW' markeert de gebeurtenissen vanaf vorige week om 9:30 uur als niet-gelezen
-      Als een niet-gelezen gebeurtenis wordt gevraagd door abonnee 'SZW'
-      Dan wordt er geen gebeurtenis geleverd
+    Scenario: Een abonnee probeert alle gebeurtenissen op ongelezen te zetten vanaf een moment vóór het zetten van het abonnement
+      Gegeven abonnee 'SZW' is gisteren om 9:32 uur geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      Als abonnee 'SZW' de gebeurtenissen vanaf vorige week om 7:00 uur als niet-gelezen markeert
+      Dan is de response '400 Bad Request'
 
   Regel: Alleen gebeurtenissen van minder dan 2 maanderen geleden kunnen op ongelezen worden gezet
     Wanneer de vanafdatum ligt voor de oudst beschikbare gebeurtenis, dan worden alle nog wel beschikbare gebeurtenissen op niet-gelezen gezet.
     Wanneer de opgegeven gebeurtenis niet meer beschikbaar is, dan worden alle nog wel beschikbare gebeurtenissen op niet-gelezen gezet.
 
-    Scenario: De abonnee probeert gebeurtenissen van meer dan 2 maanden geleden op ongelezen te zetten
+    Scenario: De abonnee probeert alle gebeurtenissen van meer dan 2 maanden geleden op ongelezen te zetten
       Als abonnee 'SZW' de gebeurtenissen vanaf 4 maanden geleden om 9:30 uur als niet-gelezen markeert
       Dan is de response '400 Bad Request'
 
   Regel: Als de abonnee gebeurtenissen op ongelezen wil zetten met een gebeurtenis id die niet bekend is of niet meer beschikbaar is, dan wordt een foutmelding gegeven
+    Er wordt een foutmelding gegeven wanneer:
+    - er geen gebeurtenis wordt gevonden met de opgegeven gebeurtenis id
+    - de abonnee geen abonnement heeft op de opgegeven gebeurtenis id (de abonnee kan deze gebeurtenis id dus niet kennen en heeft dan evident een verkeerde id opgegeven)
+    - de gebeurtenis niet meer beschikbaar is omdat deze meer dan 2 maanden geleden heeft plaatsgevonden, en daarom is verwijderd
 
-    Scenario: De abonnee probeert gebeurtenissen na een gebeurtenis die die bekend is op ongelezen te zetten
+    Scenario: De abonnee probeert alle gebeurtenissen na een gebeurtenis die niet bekend is op ongelezen te zetten
       Als abonnee 'SZW' de gebeurtenissen na de gebeurtenis met id 99999999 als niet-gelezen markeert
       Dan is de response '400 Bad Request'
 
-    Scenario: De abonnee probeert gebeurtenissen na een gebeurtenis die meer dan 2 maanden geleden heeft plaatsgevonden op ongelezen te zetten
-      Gegeven 3 maanden geleden om 9:32 uur is de aangifte van adreswijziging van 'Jan' verwerkt
+    Scenario: De abonnee probeert alle gebeurtenissen na een gebeurtenis die meer dan 2 maanden geleden heeft plaatsgevonden op ongelezen te zetten
+      Gegeven abonnee 'SZW' is geabonneerd op de 'verhuisd.intergemeentelijk' gebeurtenissen van 'Jan'
+      En 3 maanden geleden om 9:32 uur is de aangifte van adreswijziging van 'Jan' verwerkt
       * verblijft vanaf '1-9-2025' op het adres 'Stadserf_1_Roosendaal'
-      Als abonnee 'SZW' markeert de gebeurtenissen na de gebeurtenis 'verhuisd.intergemeentelijk' van 'Jan' als niet-gelezen
+      Als abonnee 'SZW' de gebeurtenissen na de gebeurtenis 'verhuisd.intergemeentelijk' van 'Jan' als niet-gelezen markeert
       Dan is de response '400 Bad Request'


### PR DESCRIPTION
Regels:
1. - [ ] Een abonnee ontvangt steeds de oudste niet-gelezen gebeurtenis
2. - [ ] Als er voor de abonnee geen niet-gelezen gebeurtenissen zijn, krijgt hij een leeg antwoord
3. - [ ] Een abonnee krijgt alleen gebeurtenissen waarop hij geabonneerd is
4. - [ ] Meerdere abonnees kunnen dezelfde gebeurtenis ontvangen
5. - [ ] Een abonnee ontvangt alleen gebeurtenissen die hebben plaatsgevonden na het plaatsen van het abonnement daarop
6. - [ ] Alleen een abonnee mag gebeurtenissen bevragen
7. - [ ] Een abonnee kan gebeurtenissen vanaf een bepaald tijdstip als niet-gelezen markeren
8. - [ ] Een abonnee kan gebeurtenissen na een bepaalde gebeurtenis als niet-gelezen markeren
9. - [ ] Gebeurtenissen ouder dan 2 maanden zijn ze niet meer op te vragen
