### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 De BRP Gebeurtenissen en Notificaties vangt mutaties aan personen in de Basis Registratie af, vertaalt deze mutaties naar gebeurtenissen en legt ze vervolgens in tijd vast.
 
-Geautoriseerde afnemers kunnen deze gebeurtenissen bevragen om hun processen en dienstverlening hierop te baseren. Een afnemer kan zich abonneren op specifieke gebeurtenissen of op specifieke gebeurtenissen van personen die zij moeten volgen voor hun dienstverlening. De afnemer wordt dan genotificeerd wanneer de specifieke gebeurtenis van de gevolgde persoon heeft plaatsgevonden. Het grote voordeel hiervan is dat afnemers niet periodiek de BRP hoeft te bevragen om zelf te achterhalen of specifieke gebeurtenissen bij specifieke personen heeft plaatsgevonden.
+Geautoriseerde afnemers kunnen deze gebeurtenissen bevragen om hun processen en dienstverlening hierop te baseren. Een afnemer kan zich abonneren op specifieke gebeurtenissen of op specifieke gebeurtenissen van personen die zij moeten volgen voor hun dienstverlening. De afnemer wordt vervolgens in staat gesteld om op te vragen of de specifieke gebeurtenis van de gevolgde persoon heeft plaatsgevonden. Het grote voordeel hiervan is dat afnemers niet periodiek de BRP hoeft te bevragen om zelf te achterhalen of specifieke gebeurtenissen bij specifieke personen heeft plaatsgevonden.
 
 ```mermaid
     flowchart LR
@@ -11,12 +11,12 @@ Geautoriseerde afnemers kunnen deze gebeurtenissen bevragen om hun processen en 
         direction LR
 
         BRP
-        BRPAfn[BRP Afnemers]
+        BRPAfn[BRP Afnemer]
 
         BRPGN[**BRP Gebeurtenissen en Notificaties**]
 
-        BRPGN -- afvangen van persoon mutaties --> BRP
-        BRPGN -- stuurt gebeurtenis notificaties naar --> BRPAfn
+        BRP -- aanleveren van gebeurtenissen --> BRPGN
+        BRPAfn -- abonneert op gebeurtenis --> BRPGN
         BRPAfn -- bevraagt gebeurtenis --> BRPGN
 
     end


### PR DESCRIPTION
Tekst en diagram meer in lijn gebracht met hoe een en ander daadwerkelijk werkt volgens https://github.com/BRP-API/brp-api-gebeurtenissen/blob/main/architectuur/sequence-diagram.md#sequence-diagram-ongelezen-gebeurtenissen-bevragen-door-afnemer. Er is geen sprake van actief notificeren van een afnemer; de afnemer moet zelf gebeurtenissen ophalen.