### PR TITLE
feat: remove oneOf from gebeurtenis definition

### DIFF
--- a/scripts/remove-oneof-from-gebeurtenis-spec.js
+++ b/scripts/remove-oneof-from-gebeurtenis-spec.js
@@ -74,15 +74,24 @@ const gebeurtenisBlockWithoutOneof = `    Gebeurtenis:
           nl.brp.verhuisd.naar-buitenland: '#/components/schemas/VerhuisdNaarBuitenland'
           nl.brp.overleden: '#/components/schemas/Overleden'`;
 
-function replaceOnce(input, needle, replacement) {
-    const occurrences = input.split(needle).length - 1;
-    return input.replace(needle, replacement);
+function replaceFirstOccurrence(input, current, replacement) {
+    const occurrences = input.split(current).length - 1;
+
+    if (occurrences === 0) {
+        throw new Error('Geen match gevonden. Controleer of het element bestaat in de specificatie.');
+    }
+
+    const transformed = input.replace(current, replacement);
+
+    console.log('Match gevonden en vervangen');
+
+    return transformed;
 }
 
 const source = fs.readFileSync(sourcePath, 'utf8');
 
-let transformed = replaceOnce(source, gebeurtenisBlock, gebeurtenisBlockWithoutOneof);
+let transformed = replaceFirstOccurrence(source, gebeurtenisBlock, gebeurtenisBlockWithoutOneof);
 
 fs.writeFileSync(outputPath, transformed, 'utf8');
 
-console.log(`Wrote ${path.relative(process.cwd(), outputPath)}`);
+console.log(`${path.relative(process.cwd(), outputPath)}`);

--- a/scripts/remove-oneof-from-gebeurtenis-spec.js
+++ b/scripts/remove-oneof-from-gebeurtenis-spec.js
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Maakt een extra specificatie aan voor gebeurtenissen-bevragen-service en verwijdert de oneOf uit de Gebeurtenis definitie in de OpenAPI specificatie, zodat deze beter te gebruiken is met openapi-generator voor java-spring.
+ *
+ * node ./scripts/remove-oneof-from-gebeurtenis-spec.js
+ *
+ * OAS3.0 feature support voor anyOf, oneOf, callbacks, etc staan op de short-term roadmap van openapi-generator. https://openapi-generator.tech/docs/roadmap
+ */
+
+const sourcePath = process.argv[2]
+    ? path.resolve(process.argv[2])
+    : path.resolve(
+        __dirname,
+        '..',
+        'specificaties',
+        'gebeurtenissen-bevragen-service',
+        'resolved',
+        'openapi.yaml'
+    );
+
+const outputPath = process.argv[3]
+    ? path.resolve(process.argv[3])
+    : path.join(path.dirname(sourcePath), 'openapi-java-spring.yaml');
+
+const gebeurtenisBlock = `    Gebeurtenis:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/iddef'
+        source:
+          $ref: '#/components/schemas/sourcedef'
+        specversion:
+          $ref: '#/components/schemas/specversiondef'
+        type:
+          $ref: '#/components/schemas/typedef'
+      required:
+        - id
+        - source
+        - specversion
+        - type
+      oneOf:
+        - $ref: '#/components/schemas/VerhuisdIntergemeentelijk'
+        - $ref: '#/components/schemas/VerhuisdNaarBuitenland'
+        - $ref: '#/components/schemas/Overleden'
+      discriminator:
+        propertyName: type
+        mapping:
+          nl.brp.verhuisd.intergemeentelijk: '#/components/schemas/VerhuisdIntergemeentelijk'
+          nl.brp.verhuisd.naar-buitenland: '#/components/schemas/VerhuisdNaarBuitenland'
+          nl.brp.overleden: '#/components/schemas/Overleden'`;
+
+const gebeurtenisBlockWithoutOneof = `    Gebeurtenis:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/iddef'
+        source:
+          $ref: '#/components/schemas/sourcedef'
+        specversion:
+          $ref: '#/components/schemas/specversiondef'
+        type:
+          $ref: '#/components/schemas/typedef'
+      required:
+        - id
+        - source
+        - specversion
+        - type
+      discriminator:
+        propertyName: type
+        mapping:
+          nl.brp.verhuisd.intergemeentelijk: '#/components/schemas/VerhuisdIntergemeentelijk'
+          nl.brp.verhuisd.naar-buitenland: '#/components/schemas/VerhuisdNaarBuitenland'
+          nl.brp.overleden: '#/components/schemas/Overleden'`;
+
+function replaceOnce(input, needle, replacement) {
+    const occurrences = input.split(needle).length - 1;
+    return input.replace(needle, replacement);
+}
+
+const source = fs.readFileSync(sourcePath, 'utf8');
+
+let transformed = replaceOnce(source, gebeurtenisBlock, gebeurtenisBlockWithoutOneof);
+
+fs.writeFileSync(outputPath, transformed, 'utf8');
+
+console.log(`Wrote ${path.relative(process.cwd(), outputPath)}`);

--- a/specificaties/brp-api/gebeurtenissen/gebeurtenis-v1.yaml
+++ b/specificaties/brp-api/gebeurtenissen/gebeurtenis-v1.yaml
@@ -20,6 +20,10 @@ components:
         - source
         - specversion
         - type
+      oneOf:
+        - $ref: 'verhuisd-intergemeentelijk-v1.yaml#/components/schemas/VerhuisdIntergemeentelijk'
+        - $ref: 'verhuisd-naar-buitenland-v1.yaml#/components/schemas/VerhuisdNaarBuitenland'
+        - $ref: 'overleden-v1.yaml#/components/schemas/Overleden'
       discriminator: 
         propertyName: type
         mapping:


### PR DESCRIPTION
fix #158 

Updates aan de OpenAPI-specificatie:

Het Gebeurtenis-schema in gebeurtenis-v1.yaml bijgewerkt met een oneOf-veld dat verwijst naar de mogelijke gebeurtenistypen, zodat de specificatie beter aansluit op de OpenAPI Standaard


Script toegevoegd:

Een nieuw script toegevoegd (scripts/remove-oneof-from-gebeurtenis-spec.js) dat een kopie van de OpenAPI-specificatie maakt waarin oneOf is verwijderd uit het Gebeurtenis-schema, zodat deze eenvoudiger te gebruiken is met codegeneratietools voor Java Spring.
