### PR TITLE
feat: naam abonnee meer karakters toestaan

### DIFF
--- a/features/abonnementen-service/registreer-abonnee.feature
+++ b/features/abonnementen-service/registreer-abonnee.feature
@@ -1,5 +1,4 @@
 # language: nl
-
 Functionaliteit: Registreer abonnee
   Als afnemer van BRP API Gebeurtenissen
   wil ik mijn interne afnemers (applicaties, processen) als abonnee kunnen registreren
@@ -21,9 +20,9 @@ Functionaliteit: Registreer abonnee
         | Gemeente Amsterdam | jz          |
 
   Regel: Een geldige abonneenaam voldoet aan de volgende criteria:
-          - bevat alleen kleine letters (a-z) en een koppelteken (-)
+          - bevat alleen kleine letters (a-z), cijfers (0-9) en koppeltekens (-)
           - bevat geen dubbele koppeltekens achter elkaar (--)
-          - bevat minimaal 2 en maximaal 10 tekens
+          - bevat minimaal 2 en maximaal 64 tekens
           - begint en eindigt niet met een koppelteken (-)
 
     Abstract Scenario: <titel>
@@ -31,14 +30,14 @@ Functionaliteit: Registreer abonnee
       Dan is de response '400 Bad Request'
 
       Voorbeelden:
-        | titel                                              | abonneeNaam |
-        | De abonneenaam is te kort                          | a           |
-        | De abonneenaam is te lang                          | abcdefghijk |
-        | De abonneenaam bevat hoofdletters                  | JZ          |
-        | De abonneenaam bevat een koppelteken aan het begin | -jz         |
-        | De abonneenaam bevat een koppelteken aan het einde | jz-         |
-        | De abonneenaam bevat dubbele koppeltekens          | j--z        |
-        | De abonneenaam bevat een ongeldig teken           | j_z         |
+        | titel                                              | abonneeNaam                                                       |
+        | De abonneenaam is te kort                          | a                                                                 |
+        | De abonneenaam is te lang                          | abcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefgha |
+        | De abonneenaam bevat hoofdletters                  | JZ                                                                |
+        | De abonneenaam bevat een koppelteken aan het begin | -jz                                                               |
+        | De abonneenaam bevat een koppelteken aan het einde | jz-                                                               |
+        | De abonneenaam bevat dubbele koppeltekens          | j--z                                                              |
+        | De abonneenaam bevat een ongeldig teken            | j_z                                                               |
 
   Regel: De abonneenaam is uniek binnen de context van een afnemer
 

--- a/specificaties/abonnementen-en-bevragen/resolved/openapi.yaml
+++ b/specificaties/abonnementen-en-bevragen/resolved/openapi.yaml
@@ -177,15 +177,17 @@ components:
   schemas:
     AbonneeNaam:
       type: string
-      pattern: ^(?!.*--)[a-z][a-z-]{0,8}[a-z]$
+      minLength: 2
+      maxLength: 64
+      pattern: ^[a-z0-9]+(?:-[a-z0-9]+)*$
       description: |
         De naam van de abonnee. 
-        Moet voldoen aan de volgende regels:
-          - Begint en eindigt met een kleine letter
-          - Bevat minimaal 2 en maximaal 10 tekens
-          - Bevat alleen kleine letters (a-z) en koppeltekens (-)
-          - Bevat geen dubbele koppeltekens (--)
-      example: abonnee
+        Moet voldoen aan de volgende criteria:
+          - bevat alleen kleine letters (a-z), cijfers (0-9) en koppeltekens (-)
+          - bevat geen dubbele koppeltekens achter elkaar (--)
+          - bevat minimaal 2 en maximaal 64 tekens
+          - begint en eindigt niet met een koppelteken (-)
+      example: abonnee-voorbeeld-001
     Abonnee:
       type: object
       properties:

--- a/specificaties/abonnementen-service/resolved/openapi.yaml
+++ b/specificaties/abonnementen-service/resolved/openapi.yaml
@@ -143,15 +143,17 @@ components:
   schemas:
     AbonneeNaam:
       type: string
-      pattern: ^(?!.*--)[a-z][a-z-]{0,8}[a-z]$
+      minLength: 2
+      maxLength: 64
+      pattern: ^[a-z0-9]+(?:-[a-z0-9]+)*$
       description: |
         De naam van de abonnee. 
-        Moet voldoen aan de volgende regels:
-          - Begint en eindigt met een kleine letter
-          - Bevat minimaal 2 en maximaal 10 tekens
-          - Bevat alleen kleine letters (a-z) en koppeltekens (-)
-          - Bevat geen dubbele koppeltekens (--)
-      example: abonnee
+        Moet voldoen aan de volgende criteria:
+          - bevat alleen kleine letters (a-z), cijfers (0-9) en koppeltekens (-)
+          - bevat geen dubbele koppeltekens achter elkaar (--)
+          - bevat minimaal 2 en maximaal 64 tekens
+          - begint en eindigt niet met een koppelteken (-)
+      example: abonnee-voorbeeld-001
     Abonnee:
       type: object
       properties:

--- a/specificaties/brp-api/abonnee/naam-v1.yaml
+++ b/specificaties/brp-api/abonnee/naam-v1.yaml
@@ -6,12 +6,14 @@ components:
   schemas:
     AbonneeNaam:
       type: string
-      pattern: '^(?!.*--)[a-z][a-z-]{0,8}[a-z]$'
+      minLength: 2
+      maxLength: 64
+      pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
       description: |
         De naam van de abonnee. 
-        Moet voldoen aan de volgende regels:
-          - Begint en eindigt met een kleine letter
-          - Bevat minimaal 2 en maximaal 10 tekens
-          - Bevat alleen kleine letters (a-z) en koppeltekens (-)
-          - Bevat geen dubbele koppeltekens (--)
-      example: abonnee
+        Moet voldoen aan de volgende criteria:
+          - bevat alleen kleine letters (a-z), cijfers (0-9) en koppeltekens (-)
+          - bevat geen dubbele koppeltekens achter elkaar (--)
+          - bevat minimaal 2 en maximaal 64 tekens
+          - begint en eindigt niet met een koppelteken (-)
+      example: abonnee-voorbeeld-001

--- a/specificaties/gebeurtenissen-bevragen-service/resolved/openapi.yaml
+++ b/specificaties/gebeurtenissen-bevragen-service/resolved/openapi.yaml
@@ -67,15 +67,17 @@ components:
           maxItems: 10
     AbonneeNaam:
       type: string
-      pattern: ^(?!.*--)[a-z][a-z-]{0,8}[a-z]$
+      minLength: 2
+      maxLength: 64
+      pattern: ^[a-z0-9]+(?:-[a-z0-9]+)*$
       description: |
         De naam van de abonnee. 
-        Moet voldoen aan de volgende regels:
-          - Begint en eindigt met een kleine letter
-          - Bevat minimaal 2 en maximaal 10 tekens
-          - Bevat alleen kleine letters (a-z) en koppeltekens (-)
-          - Bevat geen dubbele koppeltekens (--)
-      example: abonnee
+        Moet voldoen aan de volgende criteria:
+          - bevat alleen kleine letters (a-z), cijfers (0-9) en koppeltekens (-)
+          - bevat geen dubbele koppeltekens achter elkaar (--)
+          - bevat minimaal 2 en maximaal 64 tekens
+          - begint en eindigt niet met een koppelteken (-)
+      example: abonnee-voorbeeld-001
     Cursor:
       description: Geef de id van de laatst ontvangen gebeurtenis op om de volgende ongelezen gebeurtenissen te ontvangen. Cursor moet een geldige id van een gebeurtenis zijn.
       type: string


### PR DESCRIPTION
Validatiecriteria op abonneeNaam uitgebreid naar de volgende criteria:

  - bevat alleen kleine letters (a-z), cijfers (0-9) en koppeltekens (-)
  - bevat geen dubbele koppeltekens achter elkaar (--)
  - bevat minimaal 2 en maximaal 64 tekens
  - begint en eindigt niet met een koppelteken (-)


Feature [registreren abonnee](https://github.com/BRP-API/brp-api-gebeurtenissen/blob/oas/137-naam-abonnee-meer-dan-10-karakters/features/abonnementen-service/registreer-abonnee.feature) is ook bijgewerkt.

[Redoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/BRP-API/brp-api-gebeurtenissen/refs/heads/oas/137-naam-abonnee-meer-dan-10-karakters/specificaties/abonnementen-en-bevragen/resolved/openapi.yaml)