### PR TITLE
Chore/138 token langer laten leven in probeeromgeving

### DIFF
--- a/.docker/realm.json
+++ b/.docker/realm.json
@@ -36,7 +36,7 @@
             "publicClient": false,
             "protocol": "openid-connect",
             "attributes": {
-                "access.token.lifespan": "599",
+                "access.token.lifespan": "86400",
                 "oauth2.device.authorization.grant.enabled": "false",
                 "oidc.ciba.grant.enabled": "false"
             },
@@ -73,7 +73,7 @@
             "publicClient": false,
             "protocol": "openid-connect",
             "attributes": {
-                "access.token.lifespan": "300",
+                "access.token.lifespan": "86400",
                 "oauth2.device.authorization.grant.enabled": "false",
                 "oidc.ciba.grant.enabled": "false"
             },
@@ -110,7 +110,7 @@
             "publicClient": false,
             "protocol": "openid-connect",
             "attributes": {
-                "access.token.lifespan": "300",
+                "access.token.lifespan": "86400",
                 "oauth2.device.authorization.grant.enabled": "false",
                 "oidc.ciba.grant.enabled": "false"
             },
@@ -147,7 +147,7 @@
             "publicClient": false,
             "protocol": "openid-connect",
             "attributes": {
-                "access.token.lifespan": "300",
+                "access.token.lifespan": "86400",
                 "oauth2.device.authorization.grant.enabled": "false",
                 "oidc.ciba.grant.enabled": "false"
             },
@@ -184,7 +184,7 @@
             "publicClient": false,
             "protocol": "openid-connect",
             "attributes": {
-                "access.token.lifespan": "300",
+                "access.token.lifespan": "86400",
                 "oauth2.device.authorization.grant.enabled": "false",
                 "oidc.ciba.grant.enabled": "false"
             },
@@ -221,7 +221,7 @@
             "publicClient": false,
             "protocol": "openid-connect",
             "attributes": {
-                "access.token.lifespan": "300",
+                "access.token.lifespan": "86400",
                 "oauth2.device.authorization.grant.enabled": "false",
                 "oidc.ciba.grant.enabled": "false"
             },

--- a/features/docs/gegeven-stap-definities-afnemer.feature
+++ b/features/docs/gegeven-stap-definities-afnemer.feature
@@ -68,7 +68,7 @@ Functionaliteit: Afnemer gegeven stap definities
         "publicClient": false,
         "protocol": "openid-connect",
         "attributes": {
-          "access.token.lifespan": "300",
+          "access.token.lifespan": "86400",
           "oauth2.device.authorization.grant.enabled": "false",
           "oidc.ciba.grant.enabled": "false"
         }
@@ -121,7 +121,7 @@ Functionaliteit: Afnemer gegeven stap definities
         "publicClient": false,
         "protocol": "openid-connect",
         "attributes": {
-          "access.token.lifespan": "300",
+          "access.token.lifespan": "86400",
           "oauth2.device.authorization.grant.enabled": "false",
           "oidc.ciba.grant.enabled": "false"
         }

--- a/features/step_definitions/support/oauth-helpers.ts
+++ b/features/step_definitions/support/oauth-helpers.ts
@@ -89,7 +89,7 @@ export function generateClientJSON(clientId: string, clientSecret: string): any 
             publicClient: false,
             protocol: 'openid-connect',
             attributes: {
-                'access.token.lifespan': '300',
+                'access.token.lifespan': '86400',
                 'oauth2.device.authorization.grant.enabled': 'false',
                 'oidc.ciba.grant.enabled': 'false'
             }


### PR DESCRIPTION
Token lifespan aangepast naar 24h (86400 seconden)